### PR TITLE
groqu chan

### DIFF
--- a/VULTR_DEPLOY.md
+++ b/VULTR_DEPLOY.md
@@ -1,0 +1,93 @@
+# Quick Docker Deployment Guide for Vultr Server
+
+## Method 1: Using the Deployment Script
+
+1. Copy the `deploy-vultr.sh` script to your Vultr server:
+```bash
+scp deploy-vultr.sh root@139.84.170.181:/root/
+```
+
+2. SSH into your server and run the script:
+```bash
+ssh root@139.84.170.181
+chmod +x deploy-vultr.sh
+./deploy-vultr.sh
+```
+
+## Method 2: Manual Docker Deployment
+
+1. SSH into your Vultr server:
+```bash
+ssh root@139.84.170.181
+```
+
+2. Install Docker:
+```bash
+curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+```
+
+3. Clone your repository:
+```bash
+git clone <YOUR_REPO_URL> /opt/unicompass
+cd /opt/unicompass/backend
+```
+
+4. Create production environment file:
+```bash
+cp .env.production .env
+nano .env  # Edit with your API keys
+```
+
+5. Build and run:
+```bash
+docker build -t unicompass-backend .
+docker run -d --name unicompass --restart unless-stopped -p 80:5000 --env-file .env unicompass-backend
+```
+
+## Method 3: Using Docker Compose (Recommended)
+
+1. After cloning the repository:
+```bash
+cd /opt/unicompass/backend
+cp .env.production .env
+nano .env  # Edit with your API keys
+```
+
+2. Deploy with Docker Compose:
+```bash
+docker-compose up -d
+```
+
+## Verify Deployment
+
+```bash
+# Check container status
+docker ps
+
+# Check logs
+docker logs unicompass
+
+# Test API
+curl http://139.84.170.181/health
+```
+
+## Your API Endpoints
+
+Once deployed, your API will be available at:
+- Base URL: `http://139.84.170.181`
+- Health Check: `http://139.84.170.181/health`
+- All endpoints from your ENDPOINT_USAGE.md
+
+## Maintenance Commands
+
+```bash
+# Update application
+cd /opt/unicompass && git pull
+docker-compose down && docker-compose up -d --build
+
+# View logs
+docker logs -f unicompass
+
+# Restart service
+docker restart unicompass
+```

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,0 +1,31 @@
+# Flask Configuration
+DEBUG=false
+PORT=5000
+SECRET_KEY=CHANGE-THIS-TO-A-SECURE-SECRET-KEY
+
+# Groq API Configuration (for LLM functionality)
+OPENAI_API_KEY=gsk_your_groq_api_key_here
+OPENAI_MODEL=llama3-8b-8192
+MAX_TOKENS=2000
+TEMPERATURE=0.3
+
+# Azure Document Intelligence Configuration (for OCR)
+DOCUMENTINTELLIGENCE_API_KEY=your_azure_doc_intelligence_key_here
+DOCUMENTINTELLIGENCE_ENDPOINT=https://your-resource.cognitiveservices.azure.com/
+
+# Gemini API Configuration (for SOP functionality)
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# Database Configuration
+DATABASE_URL=sqlite:///unicompass.db
+
+# Cache Configuration
+CACHE_SIZE=128
+CACHE_TTL=3600
+
+# File Upload Configuration
+MAX_FILE_SIZE=16777216
+UPLOAD_FOLDER=/tmp/uploads
+
+# Logging Configuration
+LOG_LEVEL=INFO

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  unicompass-backend:
+    build: .
+    container_name: unicompass
+    restart: unless-stopped
+    ports:
+      - "80:5000"
+    environment:
+      - DEBUG=false
+      - PORT=5000
+    env_file:
+      - .env
+    volumes:
+      - ./uploads:/app/uploads
+      - ./logs:/app/logs
+      - ./data:/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/backend/old/llmEnhancer/llmenhancer.py
+++ b/backend/old/llmEnhancer/llmenhancer.py
@@ -86,7 +86,7 @@ def _assert_univ_input(univs: Any) -> List[Dict[str, Any]]:
 
 
 def _call_groq(system_prompt: str, user_prompt: str, temperature: float = 0.2) -> str:
-    api_key = "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"
+    api_key = os.getenv("GROQ_API_KEY")
     if not api_key:
         raise RuntimeError("GROQ_API_KEY is not set.")
     client = Groq(api_key=api_key)


### PR DESCRIPTION
This pull request updates how the Groq API key is retrieved in the `_call_groq` function, switching from a hardcoded value to using the `GROQ_API_KEY` environment variable. This change improves security and makes the codebase more flexible for different environments.

Security and configuration improvement:

* Updated `_call_groq` in `llmenhancer.py` to fetch the Groq API key from the `GROQ_API_KEY` environment variable instead of using a hardcoded value.